### PR TITLE
Fix position of embedded widget_class' sub widgets

### DIFF
--- a/fl2rust/src/gen.rs
+++ b/fl2rust/src/gen.rs
@@ -556,10 +556,10 @@ fn add_widget_class_ctor(w: &Widget, named: &mut Vec<(String, String)>) -> Strin
     if let Some(v) = &w.props.color {
         writeln!(wid, "\t{}.set_color(Color::by_index({}));", name, v).unwrap();
     }
-    wid += "\tbase_group.end();\n";
     if !w.children.is_empty() {
         wid += &add_widgets(Some(name), &w.children, named);
     }
+    wid += "\tbase_group.end();\n";
     wid += "\tbase_group.resize(x, y, w, h);\n";
     wid += "\tSelf {\n\t    base_group,\n";
     if !named.is_empty() {


### PR DESCRIPTION
With recent changes in "simplify adding children widgets" @ commit cf8fa30c1815d5c1e80713b71d7033b86f270ae7 the position of embedded widget_class sub widgets is lost, resulting in such widgets to be always positioned in the window's top left corner