### PR TITLE
fix gen error when string has double quotes or multiple lines

### DIFF
--- a/fl2rust/src/gen.rs
+++ b/fl2rust/src/gen.rs
@@ -38,9 +38,9 @@ use fltk::window::*;"#;
 
 fn i18nize(s: &str) -> String {
     if I18N.load(atomic::Ordering::Relaxed) {
-        format!("&tr!(\"{}\")", s)
+        format!("&tr!(r#\"{}\"#)", s)
     } else {
-        format!("\"{}\"", s)
+        format!("r#\"{}\"#", s)
     }
 }
 


### PR DESCRIPTION
Consider this

```
# data file for the Fltk User Interface Designer (fluid)
version 1.0400
i18n_type 1
i18n_include {<libintl.h>}
i18n_conditional {}
i18n_function gettext
i18n_static_function gettext_noop
header_name {.h}
code_name {.cxx}
class UserInterface {open
} {
  Function {make_window()} {open
  } {
    Fl_Window {} {open
      xywh {429 319 415 328} type Double visible
    } {
      Fl_Button btn {
        label {Button "with"}
        xywh {10 25 155 25}
      }
      Fl_Menu_Button {} {
        label menu open
        xywh {20 75 68 20}
      } {
        MenuItem {} {
          label {"Hi"
          Hi jjas}
          xywh {0 0 30 20}
        }
      }
    }
  }
}
```